### PR TITLE
Service doc on register

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   "extends": [
+    'prettier/@typescript-eslint',
     "plugin:prettier/recommended"
-  ]
+  ],
 }

--- a/client/src/lib/solana/instruction.ts
+++ b/client/src/lib/solana/instruction.ts
@@ -1,5 +1,5 @@
 import { Enum, Assignable, SCHEMA } from './solana-borsh';
-import { ClusterType } from './solid-data';
+import { ClusterType, SolidData } from './solid-data';
 import { DID_METHOD, PROGRAM_ID } from '../constants';
 import {
   AccountMeta,
@@ -12,6 +12,7 @@ import BN from 'bn.js';
 
 export class Initialize extends Assignable {
   clusterType: ClusterType;
+  initData: SolidData;
 }
 
 export class Write extends Assignable {
@@ -26,9 +27,12 @@ export class SolidInstruction extends Enum {
   write: Write;
   closeAccount: CloseAccount;
 
-  static initialize(clusterType): SolidInstruction {
+  static initialize(
+    clusterType: ClusterType,
+    initData: SolidData
+  ): SolidInstruction {
     return new SolidInstruction({
-      initialize: new Initialize({ clusterType }),
+      initialize: new Initialize({ clusterType, initData }),
     });
   }
 
@@ -55,7 +59,8 @@ export function initialize(
   payer: PublicKey,
   solidKey: PublicKey,
   authority: PublicKey,
-  clusterType: ClusterType
+  clusterType: ClusterType,
+  initData: SolidData
 ): TransactionInstruction {
   const keys: AccountMeta[] = [
     { pubkey: payer, isSigner: true, isWritable: true },
@@ -64,7 +69,7 @@ export function initialize(
     { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
-  const data = SolidInstruction.initialize(clusterType).encode();
+  const data = SolidInstruction.initialize(clusterType, initData).encode();
   return new TransactionInstruction({
     keys,
     programId: PROGRAM_ID,
@@ -101,7 +106,10 @@ SCHEMA.set(SolidInstruction, {
 });
 SCHEMA.set(Initialize, {
   kind: 'struct',
-  fields: [['clusterType', ClusterType]],
+  fields: [
+    ['clusterType', ClusterType],
+    ['initData', SolidData],
+  ],
 });
 SCHEMA.set(Write, {
   kind: 'struct',

--- a/client/src/lib/solana/transaction.ts
+++ b/client/src/lib/solana/transaction.ts
@@ -8,13 +8,14 @@ export class SolidTransaction {
     connection: Connection,
     payer: Account,
     authority: PublicKey,
-    clusterType: ClusterType
+    clusterType: ClusterType,
+    initData: SolidData
   ): Promise<PublicKey> {
     const solidKey = await getKeyFromAuthority(authority);
 
     // Allocate memory for the account
     const transaction = new Transaction().add(
-      initialize(payer.publicKey, solidKey, authority, clusterType)
+      initialize(payer.publicKey, solidKey, authority, clusterType, initData)
     );
 
     // Send the instructions

--- a/client/src/service/register.ts
+++ b/client/src/service/register.ts
@@ -1,13 +1,11 @@
-import {
-  getPublicKey,
-  makeAccount,
-  publicKeyAndClusterToDID,
-  RegisterRequest,
-  stringToPublicKey,
-} from '../lib/util';
+import { getPublicKey, makeAccount, RegisterRequest } from '../lib/util';
 import { SolidTransaction } from '../lib/solana/transaction';
-import { Connection } from '@solana/web3.js';
-import { ClusterType } from '../lib/solana/solid-data';
+import { Connection, PublicKey } from '@solana/web3.js';
+import {
+  ClusterType,
+  DistributedId,
+  SolidData,
+} from '../lib/solana/solid-data';
 
 /**
  * Registers a SOLID DID on Solana.
@@ -16,7 +14,7 @@ import { ClusterType } from '../lib/solana/solid-data';
 export const register = async (request: RegisterRequest): Promise<string> => {
   const payer = makeAccount(request.payer);
   const owner = request.owner
-    ? stringToPublicKey(request.owner)
+    ? new PublicKey(request.owner)
     : getPublicKey(request.payer);
   const cluster = request.cluster || ClusterType.mainnetBeta();
   const connection = new Connection(cluster.solanaUrl(), 'recent');
@@ -24,8 +22,9 @@ export const register = async (request: RegisterRequest): Promise<string> => {
     connection,
     payer,
     owner,
-    cluster
+    cluster,
+    SolidData.parse(request.document)
   );
 
-  return publicKeyAndClusterToDID(solidKey, cluster);
+  return DistributedId.create(solidKey, cluster).toString();
 };

--- a/client/src/service/resolve.ts
+++ b/client/src/service/resolve.ts
@@ -1,7 +1,7 @@
 import { DIDDocument } from 'did-resolver';
-import { identifierToCluster, identifierToPubkey } from '../lib/util';
 import { Connection } from '@solana/web3.js';
 import { SolidTransaction } from '../lib/solana/transaction';
+import { DistributedId } from '../lib/solana/solid-data';
 
 /**
  * Resolves a SOLID DID to a document,
@@ -10,11 +10,11 @@ import { SolidTransaction } from '../lib/solana/transaction';
  * @throws Error if the document is not found
  */
 export const resolve = async (identifier: string): Promise<DIDDocument> => {
-  const cluster = identifierToCluster(identifier);
-  const connection = new Connection(cluster.solanaUrl(), 'recent');
+  const id = DistributedId.parse(identifier);
+  const connection = new Connection(id.clusterType.solanaUrl(), 'recent');
   const solidData = await SolidTransaction.getSolid(
     connection,
-    identifierToPubkey(identifier)
+    id.pubkey.toPublicKey()
   );
   if (solidData !== null) {
     return solidData.toDID();

--- a/client/test/e2e/register.test.ts
+++ b/client/test/e2e/register.test.ts
@@ -3,7 +3,8 @@ import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { Account, Connection } from '@solana/web3.js';
 import { ServiceEndpoint } from 'did-resolver';
 import { CLUSTER, VALIDATOR_URL } from '../constants';
-import { isDID, keyToIdentifier, RegisterRequest } from '../../src/lib/util';
+import { RegisterRequest } from '../../src/lib/util';
+import { DistributedId, SolidPublicKey } from '../../src/lib/solana/solid-data';
 
 describe('register', () => {
   const connection = new Connection(VALIDATOR_URL, 'recent');
@@ -11,7 +12,11 @@ describe('register', () => {
   let owner: Account;
 
   const makeService = async (owner: Account): Promise<ServiceEndpoint> => {
-    const identifier = await keyToIdentifier(owner.publicKey, CLUSTER);
+    const identifier = new DistributedId({
+      clusterType: CLUSTER,
+      pubkey: SolidPublicKey.fromPublicKey(owner.publicKey),
+      identifier: '',
+    }).toString();
 
     return {
       description: 'Messaging Service',
@@ -37,7 +42,7 @@ describe('register', () => {
     };
     const identifier = await register(registerRequest);
 
-    expect(isDID(identifier)).toBeTruthy();
+    expect(DistributedId.valid(identifier)).toBeTruthy();
 
     console.log(identifier);
   }, 30000);

--- a/client/test/e2e/resolve.test.ts
+++ b/client/test/e2e/resolve.test.ts
@@ -24,7 +24,8 @@ describe('resolve', () => {
       connection,
       payer,
       authority.publicKey,
-      CLUSTER
+      CLUSTER,
+      SolidData.empty()
     );
   }, 60000);
 

--- a/client/test/e2e/transaction.test.ts
+++ b/client/test/e2e/transaction.test.ts
@@ -17,7 +17,8 @@ describe('transaction', () => {
       connection,
       payer,
       authority.publicKey,
-      CLUSTER
+      CLUSTER,
+      SolidData.empty()
     );
     const solid = await SolidTransaction.getSolid(connection, solidKey);
     assert.notEqual(solid, null);

--- a/client/test/unit/lib/solana/serde.test.ts
+++ b/client/test/unit/lib/solana/serde.test.ts
@@ -31,7 +31,17 @@ describe('(de)serialize operations', () => {
   });
 
   it('works for SolidInstruction.initialize', () => {
-    const instruction = SolidInstruction.initialize(ClusterType.mainnetBeta());
+    const authority = new Account();
+    const solidAccount = new Account();
+    const solidData = SolidData.sparse(
+      solidAccount.publicKey,
+      authority.publicKey,
+      ClusterType.mainnetBeta()
+    );
+    const instruction = SolidInstruction.initialize(
+      ClusterType.mainnetBeta(),
+      solidData
+    );
     testSerialization(SolidInstruction, instruction);
   });
 

--- a/client/test/unit/lib/util.test.ts
+++ b/client/test/unit/lib/util.test.ts
@@ -1,9 +1,6 @@
-import {
-  accountAndClusterToDID,
-  extractMethodIdentifierFromDID,
-  keyToIdentifier,
-} from '../../../src/lib/util';
+import { accountAndClusterToDID, keyToIdentifier } from '../../../src/lib/util';
 import { ClusterType } from '../../../src';
+import { DistributedId } from '../../../src/lib/solana/solid-data';
 import { Account, PublicKey } from '@solana/web3.js';
 import {
   TEST_DID_ACCOUNT_PUBLIC_KEY,
@@ -13,7 +10,11 @@ import {
 describe('util', () => {
   describe('extractMethodIdentifierFromDID', () => {
     it('should extract the method identifier from a DID', () => {
-      expect(extractMethodIdentifierFromDID('did:solid:abc')).toEqual('abc');
+      expect(
+        DistributedId.parse(
+          'did:solid:Bm8bvjnBCJj6nKExmZk17khkRRNXAvcv2npKbhaqNWGC'
+        ).pubkey.toString()
+      ).toEqual('Bm8bvjnBCJj6nKExmZk17khkRRNXAvcv2npKbhaqNWGC');
     });
   });
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -50,7 +50,10 @@ pub fn process_instruction(
     let account_info_iter = &mut accounts.iter();
 
     match instruction {
-        SolidInstruction::Initialize { cluster_type } => {
+        SolidInstruction::Initialize {
+            cluster_type,
+            init_data,
+        } => {
             msg!("SolidInstruction::Initialize");
 
             let funder_info = next_account_info(account_info_iter)?;
@@ -96,7 +99,8 @@ pub fn process_instruction(
             )?;
 
             let did = DistributedId::new(cluster_type, *data_info.key);
-            let solid = SolidData::new_sparse(did, *authority_info.key);
+            let mut solid = SolidData::new_sparse(did, *authority_info.key);
+            solid.merge(init_data);
             solid
                 .serialize(&mut *data_info.data.borrow_mut())
                 .map_err(|e| e.into())

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -7,8 +7,16 @@ use {
     std::str::FromStr,
 };
 
+fn merge_vecs<T: PartialEq>(lhs: &mut Vec<T>, rhs: Vec<T>) {
+    for v in rhs.into_iter() {
+        if !lhs.contains(&v) {
+            lhs.push(v);
+        }
+    }
+}
+
 /// Struct wrapping data and providing metadata
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
+#[derive(Clone, Debug, Default, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
 pub struct SolidData {
     /// DistributedId context, defaults to:
     /// ["https://w3id.org/did/v1.0", "https://w3id.org/solid/v1"]
@@ -72,6 +80,17 @@ impl SolidData {
             .filter(|v| self.capability_invocation.contains(&v.id))
             .map(|v| v.pubkey)
             .collect()
+    }
+    /// Merge one DID into another.  The ID does not change, exact copies
+    pub fn merge(&mut self, other: SolidData) {
+        merge_vecs(&mut self.context, other.context);
+        merge_vecs(&mut self.verification_method, other.verification_method);
+        merge_vecs(&mut self.authentication, other.authentication);
+        merge_vecs(&mut self.capability_invocation, other.capability_invocation);
+        merge_vecs(&mut self.capability_delegation, other.capability_delegation);
+        merge_vecs(&mut self.key_agreement, other.key_agreement);
+        merge_vecs(&mut self.assertion_method, other.assertion_method);
+        merge_vecs(&mut self.service, other.service);
     }
 }
 
@@ -203,6 +222,8 @@ pub struct ServiceEndpoint {
     pub endpoint_type: String,
     /// The actual URL of the endpoint
     pub endpoint: String,
+    /// More info about the endpoint
+    pub description: String,
 }
 
 /// Struct for the verification method


### PR DESCRIPTION
This gets the E2E test in #21 to work.  A few features:

* Add `init_data` to Initialize command, which dumbly merges the sparse DID with whatever is provided there, ie. it only checks for equality of structs before appending
* Add parsing logic from `did-resolver` types on client
* Refactor for all string parsing logic into `DistributedId` -- (TODO change that name to `DecentralizedId`, I must have had staking on the mind when I named it :laughing: )