### PR TITLE
ci: Add client e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
         working-directory: client
 
       - name: Test e2e
-        run: yarn test-e2e --ci --coverage --maxWorkers=2
+        run: yarn test-e2e --ci --coverage
         working-directory: client
 
   program-lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,13 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache node dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./client/node_modules
+          key: yarn-client-${{ hashFiles('client/yarn.lock') }}
+
       - name: Install
         run: yarn install
 
@@ -68,6 +75,75 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  client-e2e:
+    name: Test the solid client against the on-chain program on Solana ${{ matrix.solana }}, Node ${{ matrix.node }}, Rust ${{ matrix.rust }}, and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ['15.x']
+        os: [ubuntu-latest]
+        solana: ['v1.5.14']
+        rust: ['1.50']
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Use Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
+
+      - name: Cache build dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./program/target
+          key: cargo-build-${{ hashFiles('program/Cargo.lock') }}
+
+      - name: Cache Solana version
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache
+          key: solana-${{ matrix.solana }}
+
+      - name: Install Solana
+        run: |
+          sh -c "$(curl -sSfL https://release.solana.com/${{ matrix.solana }}/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Build program
+        uses: actions-rs/cargo@v1
+        with:
+          command: build-bpf
+          args: --manifest-path program/Cargo.toml
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache node dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./client/node_modules
+          key: yarn-client-${{ hashFiles('client/yarn.lock') }}
+
+      - name: Install client dependencies
+        run: yarn install
+        working-directory: client
+
+      - name: Test e2e
+        run: yarn test-e2e --ci --coverage --maxWorkers=2
+        working-directory: client
 
   program-lint:
     name: Format and lint the solid on-chain program on Rust ${{ matrix.rust }} and ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
         working-directory: client
 
       - name: Test e2e
-        run: yarn test-e2e --ci --coverage
+        run: yarn test-e2e
         working-directory: client
 
   program-lint:

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "start-validator": "solana-test-validator --bpf-program ide3Y2TubNMLLhiG1kDL6to4a8SjxD18YWCYC5BZqNV ../program/target/deploy/solid_did.so --reset --quiet",
     "test": "tsdx test --testPathIgnorePatterns=e2e",
     "test-e2e": "start-server-and-test start-validator http://localhost:8899/health test-e2e-pattern",
-    "test-e2e-pattern": "tsdx test --forceExit --testPathPattern=e2e",
+    "test-e2e-pattern": "tsdx test --testPathPattern=e2e",
     "lint": "tsdx lint --maxWarnings 0",
     "prepare": "tsdx build",
     "size": "size-limit",


### PR DESCRIPTION
Note that I tried adding the `--ci --coverage` flags to `yarn test-e2e`, but it fails due to open handles.  Not sure where those are from, but we can address that later.