### PR TITLE
program/client: Add size to init

### DIFF
--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -6,3 +6,4 @@ export const PROGRAM_ID: PublicKey = new PublicKey(
   'ide3Y2TubNMLLhiG1kDL6to4a8SjxD18YWCYC5BZqNV'
 );
 export const SOLANA_COMMITMENT: Commitment = 'confirmed';
+export const DEFAULT_DOCUMENT_SIZE = 1_000;

--- a/client/src/lib/solana/instruction.ts
+++ b/client/src/lib/solana/instruction.ts
@@ -71,7 +71,11 @@ export function initialize(
     { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
-  const data = SolidInstruction.initialize(clusterType, size, initData).encode();
+  const data = SolidInstruction.initialize(
+    clusterType,
+    size,
+    initData
+  ).encode();
   return new TransactionInstruction({
     keys,
     programId: PROGRAM_ID,

--- a/client/src/lib/solana/instruction.ts
+++ b/client/src/lib/solana/instruction.ts
@@ -8,15 +8,15 @@ import {
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
 } from '@solana/web3.js';
-import BN from 'bn.js';
 
 export class Initialize extends Assignable {
   clusterType: ClusterType;
+  size: number;
   initData: SolidData;
 }
 
 export class Write extends Assignable {
-  offset: BN;
+  offset: number;
   data: Uint8Array;
 }
 
@@ -29,14 +29,15 @@ export class SolidInstruction extends Enum {
 
   static initialize(
     clusterType: ClusterType,
+    size: number,
     initData: SolidData
   ): SolidInstruction {
     return new SolidInstruction({
-      initialize: new Initialize({ clusterType, initData }),
+      initialize: new Initialize({ clusterType, size, initData }),
     });
   }
 
-  static write(offset: BN, data: Uint8Array): SolidInstruction {
+  static write(offset: number, data: Uint8Array): SolidInstruction {
     return new SolidInstruction({ write: new Write({ offset, data }) });
   }
 
@@ -60,6 +61,7 @@ export function initialize(
   solidKey: PublicKey,
   authority: PublicKey,
   clusterType: ClusterType,
+  size: number,
   initData: SolidData
 ): TransactionInstruction {
   const keys: AccountMeta[] = [
@@ -69,7 +71,7 @@ export function initialize(
     { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
-  const data = SolidInstruction.initialize(clusterType, initData).encode();
+  const data = SolidInstruction.initialize(clusterType, size, initData).encode();
   return new TransactionInstruction({
     keys,
     programId: PROGRAM_ID,
@@ -80,7 +82,7 @@ export function initialize(
 export function write(
   solidAccount: PublicKey,
   authority: PublicKey,
-  offset: BN,
+  offset: number,
   solidData: Uint8Array
 ): TransactionInstruction {
   const keys: AccountMeta[] = [
@@ -129,6 +131,7 @@ SCHEMA.set(Initialize, {
   kind: 'struct',
   fields: [
     ['clusterType', ClusterType],
+    ['size', 'u64'],
     ['initData', SolidData],
   ],
 });

--- a/client/src/lib/solana/transaction.ts
+++ b/client/src/lib/solana/transaction.ts
@@ -7,7 +7,6 @@ import {
   write,
 } from './instruction';
 import { Account, Connection, PublicKey, Transaction } from '@solana/web3.js';
-import BN from 'bn.js';
 import { MergeBehaviour } from '../util';
 
 export class SolidTransaction {
@@ -16,13 +15,14 @@ export class SolidTransaction {
     payer: Account,
     authority: PublicKey,
     clusterType: ClusterType,
+    size: number,
     initData: SolidData
   ): Promise<PublicKey> {
     const solidKey = await getKeyFromAuthority(authority);
 
     // Allocate memory for the account
     const transaction = new Transaction().add(
-      initialize(payer.publicKey, solidKey, authority, clusterType, initData)
+      initialize(payer.publicKey, solidKey, authority, clusterType, size, initData)
     );
 
     // Send the instructions
@@ -94,7 +94,7 @@ export class SolidTransaction {
     );
 
     const transaction = new Transaction().add(
-      write(recordKey, owner.publicKey, new BN(0), mergedData.encode())
+      write(recordKey, owner.publicKey, 0, mergedData.encode())
     );
 
     // Send the instructions

--- a/client/src/lib/solana/transaction.ts
+++ b/client/src/lib/solana/transaction.ts
@@ -22,7 +22,14 @@ export class SolidTransaction {
 
     // Allocate memory for the account
     const transaction = new Transaction().add(
-      initialize(payer.publicKey, solidKey, authority, clusterType, size, initData)
+      initialize(
+        payer.publicKey,
+        solidKey,
+        authority,
+        clusterType,
+        size,
+        initData
+      )
     );
 
     // Send the instructions

--- a/client/src/lib/util.ts
+++ b/client/src/lib/util.ts
@@ -14,6 +14,7 @@ export type RegisterRequest = {
   document?: Partial<DIDDocument>;
   owner?: PublicKeyBase58;
   cluster?: ClusterType;
+  size?: number;
 };
 
 export type DeactivateRequest = {

--- a/client/src/service/register.ts
+++ b/client/src/service/register.ts
@@ -6,7 +6,7 @@ import {
   DecentralizedIdentifier,
   SolidData,
 } from '../lib/solana/solid-data';
-import { SOLANA_COMMITMENT } from '../lib/constants';
+import { DEFAULT_DOCUMENT_SIZE, SOLANA_COMMITMENT } from '../lib/constants';
 
 /**
  * Registers a SOLID DID on Solana.
@@ -18,7 +18,7 @@ export const register = async (request: RegisterRequest): Promise<string> => {
     ? new PublicKey(request.owner)
     : getPublicKey(request.payer);
   const cluster = request.cluster || ClusterType.mainnetBeta();
-  const size = request.size || 1_000;
+  const size = request.size || DEFAULT_DOCUMENT_SIZE;
   const connection = new Connection(cluster.solanaUrl(), SOLANA_COMMITMENT);
   const solidKey = await SolidTransaction.createSolid(
     connection,

--- a/client/src/service/register.ts
+++ b/client/src/service/register.ts
@@ -18,12 +18,14 @@ export const register = async (request: RegisterRequest): Promise<string> => {
     ? new PublicKey(request.owner)
     : getPublicKey(request.payer);
   const cluster = request.cluster || ClusterType.mainnetBeta();
+  const size = request.size || 1_000;
   const connection = new Connection(cluster.solanaUrl(), SOLANA_COMMITMENT);
   const solidKey = await SolidTransaction.createSolid(
     connection,
     payer,
     owner,
     cluster,
+    size,
     SolidData.parse(request.document)
   );
 

--- a/client/test/constants.ts
+++ b/client/test/constants.ts
@@ -2,6 +2,7 @@ import { ClusterType } from '../src';
 
 export const CLUSTER = ClusterType.parse(process.env.CLUSTER || 'localnet');
 export const VALIDATOR_URL = CLUSTER.solanaUrl();
+export const DOCUMENT_SIZE = 1_000;
 
 export const TEST_DID_ACCOUNT_SECRET_KEY = [
   187,

--- a/client/test/constants.ts
+++ b/client/test/constants.ts
@@ -2,7 +2,6 @@ import { ClusterType } from '../src';
 
 export const CLUSTER = ClusterType.parse(process.env.CLUSTER || 'localnet');
 export const VALIDATOR_URL = CLUSTER.solanaUrl();
-export const DOCUMENT_SIZE = 1_000;
 
 export const TEST_DID_ACCOUNT_SECRET_KEY = [
   187,

--- a/client/test/e2e/deactivate.test.ts
+++ b/client/test/e2e/deactivate.test.ts
@@ -1,9 +1,10 @@
 import { resolve, deactivate, DeactivateRequest } from '../../src';
+import { DEFAULT_DOCUMENT_SIZE } from '../../src/lib/constants';
 import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { Account, Connection, PublicKey } from '@solana/web3.js';
-import { CLUSTER, DOCUMENT_SIZE, VALIDATOR_URL } from '../constants';
+import { CLUSTER, VALIDATOR_URL } from '../constants';
 
 describe('deactivate', () => {
   const connection = new Connection(VALIDATOR_URL, 'recent');
@@ -17,7 +18,7 @@ describe('deactivate', () => {
       owner,
       owner.publicKey,
       CLUSTER,
-      DOCUMENT_SIZE,
+      DEFAULT_DOCUMENT_SIZE,
       SolidData.empty()
     );
   }, 60000);

--- a/client/test/e2e/deactivate.test.ts
+++ b/client/test/e2e/deactivate.test.ts
@@ -3,7 +3,7 @@ import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { Account, Connection, PublicKey } from '@solana/web3.js';
-import { CLUSTER, VALIDATOR_URL } from '../constants';
+import { CLUSTER, DOCUMENT_SIZE, VALIDATOR_URL } from '../constants';
 
 describe('deactivate', () => {
   const connection = new Connection(VALIDATOR_URL, 'recent');
@@ -17,6 +17,7 @@ describe('deactivate', () => {
       owner,
       owner.publicKey,
       CLUSTER,
+      DOCUMENT_SIZE,
       SolidData.empty()
     );
   }, 60000);

--- a/client/test/e2e/register.test.ts
+++ b/client/test/e2e/register.test.ts
@@ -51,4 +51,18 @@ describe('register', () => {
     // ensure the doc contains the service
     expect(doc.service).toEqual([service]);
   }, 30000);
+
+  it('registers a DID with a size', async () => {
+    const registerRequest: RegisterRequest = {
+      payer: payer.secretKey,
+      cluster: CLUSTER,
+      owner: owner.publicKey.toBase58(),
+      size: 400,
+    };
+    const identifier = await register(registerRequest);
+
+    expect(DecentralizedIdentifier.valid(identifier)).toBeTruthy();
+
+    console.log(identifier);
+  }, 30000);
 });

--- a/client/test/e2e/resolve.test.ts
+++ b/client/test/e2e/resolve.test.ts
@@ -1,11 +1,11 @@
 import { resolve } from '../../src';
+import { DEFAULT_DOCUMENT_SIZE } from '../../src/lib/constants';
 import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { Account, Connection, PublicKey } from '@solana/web3.js';
 import {
   CLUSTER,
-  DOCUMENT_SIZE,
   TEST_DID_ACCOUNT_SECRET_KEY,
   VALIDATOR_URL,
 } from '../constants';
@@ -26,7 +26,7 @@ describe('resolve', () => {
       payer,
       authority.publicKey,
       CLUSTER,
-      DOCUMENT_SIZE,
+      DEFAULT_DOCUMENT_SIZE,
       SolidData.empty()
     );
   }, 60000);

--- a/client/test/e2e/resolve.test.ts
+++ b/client/test/e2e/resolve.test.ts
@@ -5,6 +5,7 @@ import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { Account, Connection, PublicKey } from '@solana/web3.js';
 import {
   CLUSTER,
+  DOCUMENT_SIZE,
   TEST_DID_ACCOUNT_SECRET_KEY,
   VALIDATOR_URL,
 } from '../constants';
@@ -25,6 +26,7 @@ describe('resolve', () => {
       payer,
       authority.publicKey,
       CLUSTER,
+      DOCUMENT_SIZE,
       SolidData.empty()
     );
   }, 60000);

--- a/client/test/e2e/transaction.test.ts
+++ b/client/test/e2e/transaction.test.ts
@@ -1,9 +1,10 @@
 import { Account, Connection } from '@solana/web3.js';
+import { DEFAULT_DOCUMENT_SIZE } from '../../src/lib/constants';
 import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { strict as assert } from 'assert';
-import { CLUSTER, DOCUMENT_SIZE, VALIDATOR_URL } from '../constants';
+import { CLUSTER, VALIDATOR_URL } from '../constants';
 
 describe('transaction', () => {
   it('create works', async () => {
@@ -18,7 +19,7 @@ describe('transaction', () => {
       payer,
       authority.publicKey,
       CLUSTER,
-      DOCUMENT_SIZE,
+      DEFAULT_DOCUMENT_SIZE,
       SolidData.empty()
     );
     const solid = await SolidTransaction.getSolid(connection, solidKey);

--- a/client/test/e2e/transaction.test.ts
+++ b/client/test/e2e/transaction.test.ts
@@ -3,7 +3,7 @@ import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { strict as assert } from 'assert';
-import { CLUSTER, VALIDATOR_URL } from '../constants';
+import { CLUSTER, DOCUMENT_SIZE, VALIDATOR_URL } from '../constants';
 
 describe('transaction', () => {
   it('create works', async () => {
@@ -18,6 +18,7 @@ describe('transaction', () => {
       payer,
       authority.publicKey,
       CLUSTER,
+      DOCUMENT_SIZE,
       SolidData.empty()
     );
     const solid = await SolidTransaction.getSolid(connection, solidKey);

--- a/client/test/e2e/update.test.ts
+++ b/client/test/e2e/update.test.ts
@@ -1,9 +1,10 @@
 import { resolve, update, UpdateRequest } from '../../src';
+import { DEFAULT_DOCUMENT_SIZE } from '../../src/lib/constants';
 import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { Account, Connection, PublicKey } from '@solana/web3.js';
-import { CLUSTER, DOCUMENT_SIZE, VALIDATOR_URL } from '../constants';
+import { CLUSTER, VALIDATOR_URL } from '../constants';
 import { makeService } from '../util';
 import { ServiceEndpoint } from 'did-resolver';
 
@@ -31,7 +32,7 @@ describe('update', () => {
       owner,
       owner.publicKey,
       CLUSTER,
-      DOCUMENT_SIZE,
+      DEFAULT_DOCUMENT_SIZE,
       SolidData.empty()
     );
   }, 60000);

--- a/client/test/e2e/update.test.ts
+++ b/client/test/e2e/update.test.ts
@@ -3,7 +3,7 @@ import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { Account, Connection, PublicKey } from '@solana/web3.js';
-import { CLUSTER, VALIDATOR_URL } from '../constants';
+import { CLUSTER, DOCUMENT_SIZE, VALIDATOR_URL } from '../constants';
 import { makeService } from '../util';
 import { ServiceEndpoint } from 'did-resolver';
 
@@ -31,6 +31,7 @@ describe('update', () => {
       owner,
       owner.publicKey,
       CLUSTER,
+      DOCUMENT_SIZE,
       SolidData.empty()
     );
   }, 60000);

--- a/client/test/unit/lib/solana/serde.test.ts
+++ b/client/test/unit/lib/solana/serde.test.ts
@@ -5,7 +5,6 @@ import {
   SolidData,
 } from '../../../../src/lib/solana/solid-data';
 import { SolidInstruction } from '../../../../src/lib/solana/instruction';
-import { BN } from 'bn.js';
 import { strict as assert } from 'assert';
 
 describe('(de)serialize operations', () => {
@@ -40,13 +39,14 @@ describe('(de)serialize operations', () => {
     );
     const instruction = SolidInstruction.initialize(
       ClusterType.mainnetBeta(),
+      100,
       solidData
     );
     testSerialization(SolidInstruction, instruction);
   });
 
   it('works for SolidInstruction.write', () => {
-    const offset = new BN('ffffffffffffffff', 16);
+    const offset = 1_000_000;
     const data = new Uint8Array([2, 4, 1, 2, 4]);
     const instruction = SolidInstruction.write(offset, data);
     testSerialization(SolidInstruction, instruction);

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn serialize_initialize() {
         let cluster_type = ClusterType::Development;
-        let size = 1_000u64;
+        let size = SolidData::DEFAULT_SIZE as u64;
         let init_data = test_solid_data();
         let mut expected = vec![0, 3];
         expected.extend_from_slice(&size.to_le_bytes());

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -29,6 +29,8 @@ pub enum SolidInstruction {
         /// Identifier for the cluster, added to the DID if present.  For example,
         /// if we set this to "devnet", the DID becomes: "did:solid:devnet:<pubkey>"
         cluster_type: ClusterType,
+        /// Size of the DID document
+        size: u64,
         /// Additional data to write into the document
         init_data: SolidData,
     },
@@ -66,6 +68,7 @@ pub fn initialize(
     funder_account: &Pubkey,
     authority: &Pubkey,
     cluster_type: ClusterType,
+    size: u64,
     init_data: SolidData,
 ) -> Instruction {
     let (solid_account, _) = get_solid_address_with_seed(authority);
@@ -73,6 +76,7 @@ pub fn initialize(
         id(),
         &SolidInstruction::Initialize {
             cluster_type,
+            size,
             init_data,
         },
         vec![
@@ -124,11 +128,14 @@ mod tests {
     #[test]
     fn serialize_initialize() {
         let cluster_type = ClusterType::Development;
+        let size = 1_000u64;
         let init_data = test_solid_data();
         let mut expected = vec![0, 3];
+        expected.extend_from_slice(&size.to_le_bytes());
         expected.append(&mut init_data.try_to_vec().unwrap());
         let instruction = SolidInstruction::Initialize {
             cluster_type,
+            size,
             init_data,
         };
         assert_eq!(instruction.try_to_vec().unwrap(), expected);

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -52,6 +52,7 @@ pub fn process_instruction(
     match instruction {
         SolidInstruction::Initialize {
             cluster_type,
+            size,
             init_data,
         } => {
             msg!("SolidInstruction::Initialize");
@@ -86,8 +87,8 @@ pub fn process_instruction(
                 &system_instruction::create_account(
                     funder_info.key,
                     data_info.key,
-                    1.max(rent.minimum_balance(SolidData::LEN)),
-                    SolidData::LEN as u64,
+                    1.max(rent.minimum_balance(size as usize)),
+                    size,
                     &id(),
                 ),
                 &[

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -42,6 +42,8 @@ pub struct SolidData {
 }
 
 impl SolidData {
+    /// Default size of struct
+    pub const DEFAULT_SIZE: usize = 1_000;
     /// The context coming from SOLID
     pub const SOLID_CONTEXT: &'static str = "https://w3id.org/solid/v1";
     /// The default context from any DID
@@ -320,7 +322,7 @@ pub mod tests {
 
     #[test]
     fn deserialize_empty() {
-        let data = [0u8; 1_000];
+        let data = [0u8; SolidData::DEFAULT_SIZE];
         let deserialized = program_borsh::try_from_slice_incomplete::<SolidData>(&data).unwrap();
         assert_eq!(deserialized.context, vec![] as Vec<String>);
         assert_eq!(

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -42,9 +42,6 @@ pub struct SolidData {
 }
 
 impl SolidData {
-    /// Sensible large default.  The sparse DID takes up ~450 bytes.
-    pub const LEN: usize = 1_000;
-
     /// The context coming from SOLID
     pub const SOLID_CONTEXT: &'static str = "https://w3id.org/solid/v1";
     /// The default context from any DID
@@ -323,7 +320,7 @@ pub mod tests {
 
     #[test]
     fn deserialize_empty() {
-        let data = [0u8; SolidData::LEN];
+        let data = [0u8; 1_000];
         let deserialized = program_borsh::try_from_slice_incomplete::<SolidData>(&data).unwrap();
         assert_eq!(deserialized.context, vec![] as Vec<String>);
         assert_eq!(

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -110,7 +110,7 @@ async fn initialize_with_service_success() {
             &context.payer.pubkey(),
             &authority,
             cluster_type,
-            SolidData::DEFAULT_SIZE,
+            SolidData::DEFAULT_SIZE as u64,
             init_data,
         )],
         Some(&context.payer.pubkey()),

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -32,14 +32,14 @@ fn program_test() -> ProgramTest {
 async fn initialize_did_account(
     context: &mut ProgramTestContext,
     authority: &Pubkey,
-    size: u64,
+    size: usize,
 ) -> transport::Result<()> {
     let transaction = Transaction::new_signed_with_payer(
         &[instruction::initialize(
             &context.payer.pubkey(),
             authority,
             ClusterType::Development,
-            size,
+            size as u64,
             SolidData::default(),
         )],
         Some(&context.payer.pubkey()),
@@ -72,7 +72,7 @@ async fn initialize_success() {
 
     let authority = Pubkey::new_unique();
     let (solid, _) = instruction::get_solid_address_with_seed(&authority);
-    initialize_did_account(&mut context, &authority, 1_000)
+    initialize_did_account(&mut context, &authority, SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
     let account_info = context
@@ -110,7 +110,7 @@ async fn initialize_with_service_success() {
             &context.payer.pubkey(),
             &authority,
             cluster_type,
-            1_000,
+            SolidData::DEFAULT_SIZE,
             init_data,
         )],
         Some(&context.payer.pubkey()),
@@ -138,7 +138,7 @@ async fn initialize_twice_fail() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Pubkey::new_unique();
-    initialize_did_account(&mut context, &authority, 1_000)
+    initialize_did_account(&mut context, &authority, SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
     // doing what looks like the same transaction twice causes issues, so
@@ -188,7 +188,7 @@ async fn write_success() {
 
     let authority = Keypair::new();
     let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
-    initialize_did_account(&mut context, &authority.pubkey(), 1_000)
+    initialize_did_account(&mut context, &authority.pubkey(), SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
 
@@ -240,7 +240,7 @@ async fn write_fail_wrong_authority() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Keypair::new();
-    initialize_did_account(&mut context, &authority.pubkey(), 1_000)
+    initialize_did_account(&mut context, &authority.pubkey(), SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
 
@@ -281,7 +281,7 @@ async fn write_fail_unsigned() {
 
     let authority = Keypair::new();
     let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
-    initialize_did_account(&mut context, &authority.pubkey(), 1_000)
+    initialize_did_account(&mut context, &authority.pubkey(), SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
 
@@ -320,7 +320,7 @@ async fn close_account_success() {
 
     let authority = Keypair::new();
     let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
-    initialize_did_account(&mut context, &authority.pubkey(), 1_000)
+    initialize_did_account(&mut context, &authority.pubkey(), SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
     let recipient = Pubkey::new_unique();
@@ -349,7 +349,7 @@ async fn close_account_success() {
         .unwrap();
     assert_eq!(
         account.lamports,
-        1.max(Rent::default().minimum_balance(1_000))
+        1.max(Rent::default().minimum_balance(SolidData::DEFAULT_SIZE))
     );
 }
 
@@ -359,7 +359,7 @@ async fn close_account_fail_wrong_authority() {
 
     let authority = Keypair::new();
     let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
-    initialize_did_account(&mut context, &authority.pubkey(), 1_000)
+    initialize_did_account(&mut context, &authority.pubkey(), SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
     let recipient = Pubkey::new_unique();
@@ -395,7 +395,7 @@ async fn close_account_fail_unsigned() {
 
     let authority = Keypair::new();
     let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
-    initialize_did_account(&mut context, &authority.pubkey(), 1_000)
+    initialize_did_account(&mut context, &authority.pubkey(), SolidData::DEFAULT_SIZE)
         .await
         .unwrap();
 


### PR DESCRIPTION
This is pretty straightforward, mainly adding the new field and a couple of tests for it.  I removed the `BN` dependency in the client part since it wasn't explicitly required, and `number` is easier to use.