### PR TITLE
Space optimisation part 1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "build-program": "cd ../program && cargo build-bpf",
-    "start-validator": "solana-test-validator --bpf-program ide3Y2TubNMLLhiG1kDL6to4a8SjxD18YWCYC5BZqNV ../program/target/deploy/solid_did.so --reset --quiet",
+    "start-validator": "solana-test-validator --bpf-program ide3Y2TubNMLLhiG1kDL6to4a8SjxD18YWCYC5BZqNV ../program/target/deploy/solid_did.so --reset",
     "test": "tsdx test --testPathIgnorePatterns=e2e",
     "test-e2e": "start-server-and-test start-validator http://localhost:8899/health test-e2e-pattern",
     "test-e2e-pattern": "tsdx test --testPathPattern=e2e",

--- a/client/src/lib/solana/instruction.ts
+++ b/client/src/lib/solana/instruction.ts
@@ -26,10 +26,7 @@ export class SolidInstruction extends Enum {
   write: Write;
   closeAccount: CloseAccount;
 
-  static initialize(
-    size: number,
-    initData: SolidData
-  ): SolidInstruction {
+  static initialize(size: number, initData: SolidData): SolidInstruction {
     return new SolidInstruction({
       initialize: new Initialize({ size, initData }),
     });
@@ -130,8 +127,10 @@ SCHEMA.set(SolidInstruction, {
 });
 SCHEMA.set(Initialize, {
   kind: 'struct',
-  fields: [['size', 'u64'],
-    ['initData', SolidData]],
+  fields: [
+    ['size', 'u64'],
+    ['initData', SolidData],
+  ],
 });
 SCHEMA.set(Write, {
   kind: 'struct',

--- a/client/src/lib/solana/solana-borsh.ts
+++ b/client/src/lib/solana/solana-borsh.ts
@@ -12,7 +12,7 @@ export abstract class Assignable {
     return Buffer.from(serialize(SCHEMA, this));
   }
 
-  static decode(data: Buffer): any {
+  static decode<T extends Assignable>(data: Buffer): T {
     return deserializeExtraBytes(SCHEMA, this, data);
   }
 }
@@ -111,11 +111,11 @@ function deserializeStruct(
 }
 
 /// Deserializes object from bytes using schema.
-export function deserializeExtraBytes(
+export function deserializeExtraBytes<T extends Assignable>(
   schema: Schema,
   classType: any,
   buffer: Buffer
-): any {
+): T {
   const reader = new BinaryReader(buffer);
   return deserializeStruct(schema, classType, reader);
 }

--- a/client/src/lib/solana/solid-data.ts
+++ b/client/src/lib/solana/solid-data.ts
@@ -74,7 +74,6 @@ export class SolidData extends Assignable {
   static empty(): SolidData {
     return new SolidData({
       context: [],
-      did: DecentralizedIdentifier.empty(),
       verificationMethod: [],
       authentication: [],
       capabilityInvocation: [],

--- a/client/src/lib/solana/solid-data.ts
+++ b/client/src/lib/solana/solid-data.ts
@@ -11,7 +11,7 @@ import {
 
 export class SolidData extends Assignable {
   // derived
-  publicKey: SolidPublicKey;
+  account: SolidPublicKey;
   cluster: ClusterType;
 
   // persisted
@@ -32,7 +32,7 @@ export class SolidData extends Assignable {
   ): SolidData {
     const solidData = SolidData.decode<SolidData>(accountData);
     solidData.cluster = cluster;
-    solidData.publicKey = SolidPublicKey.fromPublicKey(accountKey);
+    solidData.account = SolidPublicKey.fromPublicKey(accountKey);
     return solidData;
   }
 
@@ -43,7 +43,10 @@ export class SolidData extends Assignable {
     });
   }
 
-  merge(other: SolidData, overwriteArrays: boolean = false): SolidData {
+  merge(
+    other: Partial<SolidData>,
+    overwriteArrays: boolean = false
+  ): SolidData {
     const mergeBehaviour = (a: any, b: any): any => {
       if (a && Array.isArray(a)) {
         return overwriteArrays && b ? b : [...a, ...b];
@@ -77,7 +80,7 @@ export class SolidData extends Assignable {
     const service = [];
     return new SolidData({
       cluster: clusterType,
-      publicKey: SolidPublicKey.fromPublicKey(account),
+      account: SolidPublicKey.fromPublicKey(account),
       authority: SolidPublicKey.fromPublicKey(authority),
       context,
       verificationMethod: [verificationMethod],
@@ -92,7 +95,10 @@ export class SolidData extends Assignable {
 
   static empty(): SolidData {
     return new SolidData({
+      cluster: ClusterType.mainnetBeta(),
+      // account: SolidPublicKey.fromPublicKey(new Account().publicKey),
       authority: SolidPublicKey.fromPublicKey(new Account().publicKey),
+
       context: [],
       verificationMethod: [],
       authentication: [],
@@ -107,7 +113,7 @@ export class SolidData extends Assignable {
   identifier(): DecentralizedIdentifier {
     return new DecentralizedIdentifier({
       clusterType: this.cluster,
-      pubkey: this.publicKey,
+      pubkey: this.account,
     });
   }
 

--- a/client/src/lib/solana/transaction.ts
+++ b/client/src/lib/solana/transaction.ts
@@ -21,13 +21,7 @@ export class SolidTransaction {
 
     // Allocate memory for the account
     const transaction = new Transaction().add(
-      initialize(
-        payer.publicKey,
-        solidKey,
-        authority,
-        size,
-        initData
-      )
+      initialize(payer.publicKey, solidKey, authority, size, initData)
     );
 
     // Send the instructions

--- a/client/src/lib/solana/transaction.ts
+++ b/client/src/lib/solana/transaction.ts
@@ -15,14 +15,13 @@ export class SolidTransaction {
     connection: Connection,
     payer: Account,
     authority: PublicKey,
-    clusterType: ClusterType,
     initData: SolidData
   ): Promise<PublicKey> {
     const solidKey = await getKeyFromAuthority(authority);
 
     // Allocate memory for the account
     const transaction = new Transaction().add(
-      initialize(payer.publicKey, solidKey, authority, clusterType, initData)
+      initialize(payer.publicKey, solidKey, authority, initData)
     );
 
     // Send the instructions
@@ -32,18 +31,23 @@ export class SolidTransaction {
 
   static async getSolid(
     connection: Connection,
+    clusterType: ClusterType,
     recordKey: PublicKey
   ): Promise<SolidData | null> {
     const data = await connection.getAccountInfo(recordKey);
-    return data ? SolidData.decode(data.data) : null;
+
+    if (!data) return null;
+
+    return SolidData.fromAccount(recordKey, data.data, clusterType);
   }
 
   static async getSolidFromAuthority(
     connection: Connection,
+    clusterType: ClusterType,
     authority: PublicKey
   ): Promise<SolidData | null> {
     const recordKey = await getKeyFromAuthority(authority);
-    return SolidTransaction.getSolid(connection, recordKey);
+    return SolidTransaction.getSolid(connection, clusterType, recordKey);
   }
 
   /**
@@ -77,6 +81,7 @@ export class SolidTransaction {
 
   static async updateSolid(
     connection: Connection,
+    clusterType: ClusterType,
     payer: Account,
     recordKey: PublicKey,
     dataToMerge: SolidData,
@@ -84,7 +89,11 @@ export class SolidTransaction {
     owner: Account = payer
   ): Promise<string> {
     // Update the solid DID
-    const existingData = await this.getSolid(connection, recordKey);
+    const existingData = await this.getSolid(
+      connection,
+      clusterType,
+      recordKey
+    );
 
     if (!existingData) throw new Error('DID does not exist');
 

--- a/client/src/service/register.ts
+++ b/client/src/service/register.ts
@@ -23,7 +23,6 @@ export const register = async (request: RegisterRequest): Promise<string> => {
     connection,
     payer,
     owner,
-    cluster,
     SolidData.parse(request.document)
   );
 

--- a/client/src/service/resolve.ts
+++ b/client/src/service/resolve.ts
@@ -18,10 +18,11 @@ export const resolve = async (identifier: string): Promise<DIDDocument> => {
   );
   const solidData = await SolidTransaction.getSolid(
     connection,
+    id.clusterType,
     id.pubkey.toPublicKey()
   );
   if (solidData !== null) {
-    return solidData.toDID();
+    return solidData.toDIDDocument();
   } else {
     throw new Error(`No DID found at identifier ${identifier}`);
   }

--- a/client/src/service/update.ts
+++ b/client/src/service/update.ts
@@ -15,6 +15,7 @@ export const update = async (request: UpdateRequest): Promise<void> => {
   const connection = new Connection(cluster.solanaUrl(), 'recent');
   await SolidTransaction.updateSolid(
     connection,
+    cluster,
     payer,
     id.pubkey.toPublicKey(),
     SolidData.parse(request.document),

--- a/client/test/e2e/deactivate.test.ts
+++ b/client/test/e2e/deactivate.test.ts
@@ -16,7 +16,6 @@ describe('deactivate', () => {
       connection,
       owner,
       owner.publicKey,
-      CLUSTER,
       SolidData.empty()
     );
   }, 60000);

--- a/client/test/e2e/register.test.ts
+++ b/client/test/e2e/register.test.ts
@@ -57,7 +57,7 @@ describe('register', () => {
       payer: payer.secretKey,
       cluster: CLUSTER,
       owner: owner.publicKey.toBase58(),
-      size: 400,
+      size: 250,
     };
     const identifier = await register(registerRequest);
 

--- a/client/test/e2e/register.test.ts
+++ b/client/test/e2e/register.test.ts
@@ -32,7 +32,7 @@ describe('register', () => {
   }, 30000);
 
   it('registers a DID with a document', async () => {
-    const service = makeService(owner);
+    const service = await makeService(owner);
 
     const registerRequest: RegisterRequest = {
       payer: payer.secretKey,
@@ -46,7 +46,7 @@ describe('register', () => {
 
     const doc = await resolve(identifier);
 
-    console.log({ service, doc });
+    console.log({ service, doc: JSON.stringify(doc, null, 1) });
 
     // ensure the doc contains the service
     expect(doc.service).toEqual([service]);

--- a/client/test/e2e/resolve.test.ts
+++ b/client/test/e2e/resolve.test.ts
@@ -3,11 +3,7 @@ import { SolidData } from '../../src/lib/solana/solid-data';
 import { SolanaUtil } from '../../src/lib/solana/solana-util';
 import { SolidTransaction } from '../../src/lib/solana/transaction';
 import { Account, Connection, PublicKey } from '@solana/web3.js';
-import {
-  CLUSTER,
-  TEST_DID_ACCOUNT_SECRET_KEY,
-  VALIDATOR_URL,
-} from '../constants';
+import { CLUSTER, VALIDATOR_URL } from '../constants';
 
 describe('resolve', () => {
   const connection = new Connection(VALIDATOR_URL, 'recent');
@@ -19,12 +15,11 @@ describe('resolve', () => {
       connection,
       1000000000
     );
-    authority = new Account(TEST_DID_ACCOUNT_SECRET_KEY);
+    authority = new Account();
     solidDIDKey = await SolidTransaction.createSolid(
       connection,
       payer,
       authority.publicKey,
-      CLUSTER,
       SolidData.empty()
     );
   }, 60000);
@@ -38,7 +33,7 @@ describe('resolve', () => {
       solidDIDKey,
       authority.publicKey,
       CLUSTER
-    ).toDID();
+    ).toDIDDocument();
     return expect(document).toMatchObject(expectedDocument);
   });
 });

--- a/client/test/e2e/transaction.test.ts
+++ b/client/test/e2e/transaction.test.ts
@@ -17,15 +17,19 @@ describe('transaction', () => {
       connection,
       payer,
       authority.publicKey,
-      CLUSTER,
       SolidData.empty()
     );
-    const solid = await SolidTransaction.getSolid(connection, solidKey);
+    const solid = await SolidTransaction.getSolid(
+      connection,
+      CLUSTER,
+      solidKey
+    );
     assert.notEqual(solid, null);
     const checkSolid = SolidData.sparse(solidKey, authority.publicKey, CLUSTER);
     assert.deepEqual(solid, checkSolid);
     const solidFromAuthority = await SolidTransaction.getSolidFromAuthority(
       connection,
+      CLUSTER,
       authority.publicKey
     );
     assert.deepEqual(solidFromAuthority, checkSolid);

--- a/client/test/e2e/update.test.ts
+++ b/client/test/e2e/update.test.ts
@@ -30,14 +30,13 @@ describe('update', () => {
       connection,
       owner,
       owner.publicKey,
-      CLUSTER,
       SolidData.empty()
     );
   }, 60000);
 
   it('adds a service to a DID', async () => {
     const identifier = 'did:solid:' + CLUSTER + ':' + solidDIDKey.toBase58();
-    const service = makeService(owner);
+    const service = await makeService(owner);
     const request: UpdateRequest = {
       payer: owner.secretKey,
       identifier,
@@ -60,7 +59,7 @@ describe('update', () => {
       1000000000
     );
     const identifier = 'did:solid:' + CLUSTER + ':' + solidDIDKey.toBase58();
-    const service = makeService(owner);
+    const service = await makeService(owner);
     const request: UpdateRequest = {
       payer: payer.secretKey,
       owner: owner.secretKey,
@@ -81,8 +80,8 @@ describe('update', () => {
   it('adds a service to a DID with an existing service', async () => {
     const identifier = 'did:solid:' + CLUSTER + ':' + solidDIDKey.toBase58();
 
-    const service1 = makeService(owner);
-    const service2 = makeService(owner);
+    const service1 = await makeService(owner);
+    const service2 = await makeService(owner);
 
     const request1: UpdateRequest = makeServiceRequest(
       owner,

--- a/client/test/unit/lib/solana/serde.test.ts
+++ b/client/test/unit/lib/solana/serde.test.ts
@@ -37,10 +37,7 @@ describe('(de)serialize operations', () => {
       authority.publicKey,
       ClusterType.mainnetBeta()
     );
-    const instruction = SolidInstruction.initialize(
-      100,
-      solidData
-    );
+    const instruction = SolidInstruction.initialize(100, solidData);
     testSerialization(SolidInstruction, instruction);
   });
 

--- a/client/test/unit/lib/solana/serde.test.ts
+++ b/client/test/unit/lib/solana/serde.test.ts
@@ -38,10 +38,7 @@ describe('(de)serialize operations', () => {
       authority.publicKey,
       ClusterType.mainnetBeta()
     );
-    const instruction = SolidInstruction.initialize(
-      ClusterType.mainnetBeta(),
-      solidData
-    );
+    const instruction = SolidInstruction.initialize(solidData);
     testSerialization(SolidInstruction, instruction);
   });
 

--- a/client/test/unit/lib/solana/solid-data.test.ts
+++ b/client/test/unit/lib/solana/solid-data.test.ts
@@ -9,7 +9,8 @@ import { makeService } from '../../../util';
 
 const pub = () => new Account().publicKey;
 
-const withoutAuthority = (solidData: SolidData) => omit(['authority'], solidData);
+const withoutAuthority = (solidData: SolidData) =>
+  omit(['authority'], solidData);
 
 describe('solid-data', () => {
   describe('merge', () => {
@@ -24,7 +25,7 @@ describe('solid-data', () => {
 
         const merged = empty.merge(sparse);
 
-        expect(merged).toEqual(sparse);
+        expect(merged).toMatchObject(sparse);
       });
 
       it('should not change a sparse solidData object when merging an empty one into it, except for the authority', () => {
@@ -37,9 +38,7 @@ describe('solid-data', () => {
 
         const merged = sparse.merge(empty);
 
-        expect(withoutAuthority(merged)).toEqual(
-          withoutAuthority(sparse)
-        );
+        expect(withoutAuthority(merged)).toEqual(withoutAuthority(sparse));
 
         expect(merged.authority).toEqual(empty.authority);
       });
@@ -55,7 +54,7 @@ describe('solid-data', () => {
 
         const merged = sparse.merge(empty);
 
-        expect(merged).toEqual(sparse);
+        expect(merged).toMatchObject(sparse);
       });
 
       it('should allow properties to be added to empty arrays', async () => {
@@ -108,7 +107,7 @@ describe('solid-data', () => {
 
         const merged = empty.merge(sparse, true);
 
-        expect(merged).toEqual(sparse);
+        expect(merged).toMatchObject(sparse);
       });
 
       it('should clear the contents of a solidData object when merging an empty one', () => {
@@ -121,7 +120,7 @@ describe('solid-data', () => {
 
         const merged = sparse.merge(empty, true);
 
-        expect(merged).toEqual({
+        expect(merged).toMatchObject({
           ...empty,
           account: sparse.account, // empty SolidData objects have no account
         });

--- a/client/test/unit/lib/solana/solid-data.test.ts
+++ b/client/test/unit/lib/solana/solid-data.test.ts
@@ -25,7 +25,7 @@ describe('solid-data', () => {
         expect(merged).toEqual(sparse);
       });
 
-      it('should not change a sparse solidData object when merging an empty one into it, except for the identifier', () => {
+      it('should not change a sparse solidData object when merging an empty one into it, except for the authority', () => {
         const empty = SolidData.empty();
         const sparse = SolidData.sparse(
           pub(),
@@ -35,13 +35,31 @@ describe('solid-data', () => {
 
         const merged = sparse.merge(empty);
 
-        expect(omit(['did'], merged)).toEqual(omit(['did'], sparse));
+        expect(omit(['authority'], merged)).toEqual(
+          omit(['authority'], sparse)
+        );
+
+        expect(merged.authority).toEqual(empty.authority);
       });
 
-      it('should allow properties to be added to empty arrays', () => {
+      it('should not change a sparse solidData object when merging an empty one with no authority', () => {
+        const empty = SolidData.empty() as Partial<SolidData>;
+        delete empty.authority;
+        const sparse = SolidData.sparse(
+          pub(),
+          pub(),
+          ClusterType.mainnetBeta()
+        );
+
+        const merged = sparse.merge(empty);
+
+        expect(merged).toEqual(sparse);
+      });
+
+      it('should allow properties to be added to empty arrays', async () => {
         const withService = SolidData.empty();
         withService.service = [
-          ServiceEndpoint.parse(makeService(new Account())),
+          ServiceEndpoint.parse(await makeService(new Account())),
         ];
         const sparse = SolidData.sparse(
           pub(),
@@ -54,18 +72,18 @@ describe('solid-data', () => {
         expect(merged.service).toEqual(withService.service);
       });
 
-      it('should allow properties to be added to existing arrays', () => {
+      it('should allow properties to be added to existing arrays', async () => {
         const sparseWithService = SolidData.sparse(
           pub(),
           pub(),
           ClusterType.mainnetBeta()
         );
         sparseWithService.service = [
-          ServiceEndpoint.parse(makeService(new Account())),
+          ServiceEndpoint.parse(await makeService(new Account())),
         ];
 
         const justService = new SolidData({
-          service: [ServiceEndpoint.parse(makeService(new Account()))],
+          service: [ServiceEndpoint.parse(await makeService(new Account()))],
         });
 
         const merged = sparseWithService.merge(justService);
@@ -101,21 +119,24 @@ describe('solid-data', () => {
 
         const merged = sparse.merge(empty, true);
 
-        expect(merged).toEqual(empty);
+        expect(merged).toEqual({
+          ...empty,
+          account: sparse.account, // empty SolidData objects have no account
+        });
       });
 
-      it('should allow properties to be replaced', () => {
+      it('should allow properties to be replaced', async () => {
         const sparseWithService = SolidData.sparse(
           pub(),
           pub(),
           ClusterType.mainnetBeta()
         );
         sparseWithService.service = [
-          ServiceEndpoint.parse(makeService(new Account())),
+          ServiceEndpoint.parse(await makeService(new Account())),
         ];
 
         const justService = new SolidData({
-          service: [ServiceEndpoint.parse(makeService(new Account()))],
+          service: [ServiceEndpoint.parse(await makeService(new Account()))],
         });
 
         const merged = sparseWithService.merge(justService, true);

--- a/client/test/util.ts
+++ b/client/test/util.ts
@@ -5,12 +5,14 @@ import {
   SolidPublicKey,
 } from '../src/lib/solana/solid-data';
 import { CLUSTER } from './constants';
+import { getKeyFromAuthority } from '../src/lib/solana/instruction';
 
-export const makeService = (owner: Account): ServiceEndpoint => {
+export const makeService = async (owner: Account): Promise<ServiceEndpoint> => {
+  const pubkey = await getKeyFromAuthority(owner.publicKey);
+
   const identifier = new DecentralizedIdentifier({
     clusterType: CLUSTER,
-    pubkey: SolidPublicKey.fromPublicKey(owner.publicKey),
-    identifier: '',
+    pubkey: SolidPublicKey.fromPublicKey(pubkey),
   }).toString();
 
   return {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -66,10 +66,7 @@ pub fn initialize(
     let (solid_account, _) = get_solid_address_with_seed(authority);
     Instruction::new_with_borsh(
         id(),
-        &SolidInstruction::Initialize {
-            size,
-            init_data,
-        },
+        &SolidInstruction::Initialize { size, init_data },
         vec![
             AccountMeta::new(*funder_account, true),
             AccountMeta::new(solid_account, false),
@@ -124,10 +121,7 @@ mod tests {
         let mut expected = vec![0];
         expected.extend_from_slice(&size.to_le_bytes());
         expected.append(&mut init_data.try_to_vec().unwrap());
-        let instruction = SolidInstruction::Initialize {
-            size,
-            init_data,
-        };
+        let instruction = SolidInstruction::Initialize { size, init_data };
         assert_eq!(instruction.try_to_vec().unwrap(), expected);
         assert_eq!(
             SolidInstruction::try_from_slice(&expected).unwrap(),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         id,
-        state::{ClusterType, SolidData, get_solid_address_with_seed},
+        state::{get_solid_address_with_seed, ClusterType, SolidData},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::{
@@ -26,9 +26,6 @@ pub enum SolidInstruction {
     /// 3. `[]` Rent sysvar
     /// 4. `[]` System program
     Initialize {
-        /// Identifier for the cluster, added to the DID if present.  For example,
-        /// if we set this to "devnet", the DID becomes: "did:solid:devnet:<pubkey>"
-        cluster_type: ClusterType,
         /// Additional data to write into the document
         init_data: SolidData,
     },
@@ -60,16 +57,13 @@ pub enum SolidInstruction {
 pub fn initialize(
     funder_account: &Pubkey,
     authority: &Pubkey,
-    cluster_type: ClusterType,
+    _cluster_type: ClusterType,
     init_data: SolidData,
 ) -> Instruction {
     let (solid_account, _) = get_solid_address_with_seed(authority);
     Instruction::new_with_borsh(
         id(),
-        &SolidInstruction::Initialize {
-            cluster_type,
-            init_data,
-        },
+        &SolidInstruction::Initialize { init_data },
         vec![
             AccountMeta::new(*funder_account, true),
             AccountMeta::new(solid_account, false),
@@ -118,14 +112,11 @@ mod tests {
 
     #[test]
     fn serialize_initialize() {
-        let cluster_type = ClusterType::Development;
+        let _cluster_type = ClusterType::Development;
         let init_data = test_solid_data();
-        let mut expected = vec![0, 3];
+        let mut expected = vec![0];
         expected.append(&mut init_data.try_to_vec().unwrap());
-        let instruction = SolidInstruction::Initialize {
-            cluster_type,
-            init_data,
-        };
+        let instruction = SolidInstruction::Initialize { init_data };
         assert_eq!(instruction.try_to_vec().unwrap(), expected);
         assert_eq!(
             SolidInstruction::try_from_slice(&expected).unwrap(),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         id,
-        state::{ClusterType, SolidData},
+        state::{ClusterType, SolidData, get_solid_address_with_seed},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::{
@@ -54,11 +54,6 @@ pub enum SolidInstruction {
     /// 1. `[signer]` Solid authority
     /// 2. `[]` Receiver of account lamports
     CloseAccount,
-}
-
-/// Get program-derived solid address for the authority
-pub fn get_solid_address_with_seed(authority: &Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[&authority.to_bytes(), br"solid"], &id())
 }
 
 /// Create a `SolidInstruction::Initialize` instruction

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5,8 +5,8 @@ use {
         borsh as program_borsh,
         error::SolidError,
         id,
-        instruction::{get_solid_address_with_seed, SolidInstruction},
-        state::{SolidData},
+        instruction::{SolidInstruction},
+        state::{get_solid_address_with_seed, SolidData},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::{
@@ -46,9 +46,11 @@ pub fn process_instruction(
     accounts: &[AccountInfo],
     input: &[u8],
 ) -> ProgramResult {
+    msg!("Hello");
     let instruction = SolidInstruction::try_from_slice(input)?;
     let account_info_iter = &mut accounts.iter();
 
+  msg!("Hello2");
     match instruction {
         SolidInstruction::Initialize {
             cluster_type,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -5,7 +5,7 @@ use {
         borsh as program_borsh,
         error::SolidError,
         id,
-        instruction::{SolidInstruction},
+        instruction::SolidInstruction,
         state::{get_solid_address_with_seed, SolidData},
     },
     borsh::{BorshDeserialize, BorshSerialize},
@@ -50,12 +50,9 @@ pub fn process_instruction(
     let instruction = SolidInstruction::try_from_slice(input)?;
     let account_info_iter = &mut accounts.iter();
 
-  msg!("Hello2");
+    msg!("Hello2");
     match instruction {
-        SolidInstruction::Initialize {
-            cluster_type,
-            init_data,
-        } => {
+        SolidInstruction::Initialize { init_data } => {
             msg!("SolidInstruction::Initialize");
 
             let funder_info = next_account_info(account_info_iter)?;
@@ -100,7 +97,7 @@ pub fn process_instruction(
                 &[&solid_signer_seeds],
             )?;
 
-            let mut solid = SolidData::new_sparse( *authority_info.key, cluster_type);
+            let mut solid = SolidData::new_sparse(*authority_info.key);
             solid.merge(init_data);
             solid
                 .serialize(&mut *data_info.data.borrow_mut())

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -46,16 +46,11 @@ pub fn process_instruction(
     accounts: &[AccountInfo],
     input: &[u8],
 ) -> ProgramResult {
-    msg!("Hello");
     let instruction = SolidInstruction::try_from_slice(input)?;
     let account_info_iter = &mut accounts.iter();
 
-    msg!("Hello2");
     match instruction {
-        SolidInstruction::Initialize {
-            size,
-            init_data
-        } => {
+        SolidInstruction::Initialize { size, init_data } => {
             msg!("SolidInstruction::Initialize");
 
             let funder_info = next_account_info(account_info_iter)?;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -6,7 +6,7 @@ use {
         error::SolidError,
         id,
         instruction::{get_solid_address_with_seed, SolidInstruction},
-        state::{DecentralizedIdentifier, SolidData},
+        state::{SolidData},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::{
@@ -98,8 +98,7 @@ pub fn process_instruction(
                 &[&solid_signer_seeds],
             )?;
 
-            let did = DecentralizedIdentifier::new(cluster_type, *data_info.key);
-            let mut solid = SolidData::new_sparse(did, *authority_info.key);
+            let mut solid = SolidData::new_sparse( *authority_info.key, cluster_type);
             solid.merge(init_data);
             solid
                 .serialize(&mut *data_info.data.borrow_mut())

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -163,38 +163,6 @@ pub struct DecentralizedIdentifier<'a> {
 }
 
 impl<'a> DecentralizedIdentifier<'a> {
-    /// All SOLID DIDs start with this.
-    const DEFAULT_DID_START: &'static str = "did:solid";
-
-    fn pubkey(&self) -> Pubkey {
-        get_solid_address_with_seed(&self.solid_data.authority).0
-    }
-
-    fn identifier(&self, cluster: ClusterType) -> String {
-        format!(
-            "{}:{}{}{}",
-            Self::DEFAULT_DID_START,
-            DecentralizedIdentifier::<'a>::cluster(cluster),
-            self.pubkey(),
-            self.url()
-        )
-    }
-
-    fn url(&self) -> String {
-        if self.url_field.is_empty() {
-            "".to_string()
-        } else {
-            format!("#{}", self.url_field)
-        }
-    }
-
-    fn cluster(cluster: ClusterType) -> String {
-        match cluster {
-            ClusterType::MainnetBeta => "".to_string(),
-            _ => format!("{}:", cluster.did_identifier()),
-        }
-    }
-
     /// Create new DID when no additional identifier is specified
     pub fn new(solid_data: &'a SolidData) -> Self {
         Self {

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -327,8 +327,8 @@ pub mod tests {
         let deserialized = program_borsh::try_from_slice_incomplete::<SolidData>(&data).unwrap();
         assert_eq!(deserialized.context, vec![] as Vec<String>);
         assert_eq!(
-          deserialized.did,
-          DecentralizedIdentifier {
+            deserialized.did,
+            DecentralizedIdentifier {
                 cluster_type: ClusterType::Testnet,
                 pubkey: Pubkey::new_from_array([0; 32]),
                 identifier: "".to_string()
@@ -378,22 +378,22 @@ pub mod tests {
         // no did:solid
         let invalid = "solid:devnet:FcFhBFRf6smQ48p7jFcE35uNuE9ScuUu6R2rdFtWjWhP";
         assert_eq!(
-          DecentralizedIdentifier::from_str(&invalid).unwrap_err(),
-          SolidError::InvalidString
+            DecentralizedIdentifier::from_str(&invalid).unwrap_err(),
+            SolidError::InvalidString
         );
 
         // unknown network
         let invalid = "did:solid:mynetwork:FcFhBFRf6smQ48p7jFcE35uNuE9ScuUu6R2rdFtWjWhP";
         assert_eq!(
-          DecentralizedIdentifier::from_str(&invalid).unwrap_err(),
-          SolidError::InvalidString
+            DecentralizedIdentifier::from_str(&invalid).unwrap_err(),
+            SolidError::InvalidString
         );
 
         // bad pubkey
         let invalid = "did:solid:FcFhBFRf6smQ48p7jFcE35uNuE9ScuUu6R2rdFtWjWhP111111";
         assert_eq!(
-          DecentralizedIdentifier::from_str(&invalid).unwrap_err(),
-          SolidError::InvalidString
+            DecentralizedIdentifier::from_str(&invalid).unwrap_err(),
+            SolidError::InvalidString
         );
     }
 }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,6 +1,6 @@
 //! Program state
 use {
-    crate::error::SolidError,
+    crate::{error::SolidError, id},
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     // regex::Regex,
     solana_program::{program_pack::IsInitialized, pubkey::Pubkey},
@@ -154,6 +154,11 @@ impl FromStr for ClusterType {
 }
 
 
+/// Get program-derived solid address for the authority
+pub fn get_solid_address_with_seed(authority: &Pubkey) -> (Pubkey, u8) {
+  Pubkey::find_program_address(&[&authority.to_bytes(), br"solid"], &id())
+}
+
 /// Typed representation of a DecentralizedIdentifier
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
 pub struct DecentralizedIdentifier<'a> {
@@ -164,13 +169,12 @@ pub struct DecentralizedIdentifier<'a> {
 }
 
 
-
 impl<'a> DecentralizedIdentifier<'a> {
     /// All SOLID DIDs start with this.
     const DEFAULT_DID_START: &'static str = "did:solid";
 
     fn pubkey(&self) -> Pubkey {
-      self.solid_data.authority
+      get_solid_address_with_seed(&self.solid_data.authority).0
     }
 
     fn identifier(&self) -> String {

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -21,6 +21,7 @@ use {
         processor::process_instruction,
         state::{
             ClusterType, DecentralizedIdentifier, ServiceEndpoint, SolidData, VerificationMethod,
+            get_solid_address_with_seed
         },
     },
 };
@@ -69,7 +70,7 @@ async fn initialize_success() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Pubkey::new_unique();
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority);
+    let (solid, _) = get_solid_address_with_seed(&authority);
     initialize_did_account(&mut context, &authority)
         .await
         .unwrap();
@@ -89,7 +90,7 @@ async fn initialize_with_service_success() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Pubkey::new_unique();
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority);
+    let (solid, _) = get_solid_address_with_seed(&authority);
     let mut init_data = SolidData::default();
     let cluster_type = ClusterType::Development;
     // let id = DecentralizedIdentifier::new(cluster_type.clone(), authority.clone());
@@ -168,7 +169,7 @@ async fn write_success() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Keypair::new();
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
+    let (solid, _) = get_solid_address_with_seed(&authority.pubkey());
     initialize_did_account(&mut context, &authority.pubkey())
         .await
         .unwrap();
@@ -225,7 +226,7 @@ async fn write_fail_wrong_authority() {
         .await
         .unwrap();
 
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
+    let (solid, _) = get_solid_address_with_seed(&authority.pubkey());
     let new_data = SolidData::new_sparse(
         authority.pubkey(),
         ClusterType::Development
@@ -261,7 +262,7 @@ async fn write_fail_unsigned() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Keypair::new();
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
+    let (solid, _) = get_solid_address_with_seed(&authority.pubkey());
     initialize_did_account(&mut context, &authority.pubkey())
         .await
         .unwrap();
@@ -300,7 +301,7 @@ async fn close_account_success() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Keypair::new();
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
+    let (solid, _) = get_solid_address_with_seed(&authority.pubkey());
     initialize_did_account(&mut context, &authority.pubkey())
         .await
         .unwrap();
@@ -339,7 +340,7 @@ async fn close_account_fail_wrong_authority() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Keypair::new();
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
+    let (solid, _) = get_solid_address_with_seed(&authority.pubkey());
     initialize_did_account(&mut context, &authority.pubkey())
         .await
         .unwrap();
@@ -375,7 +376,7 @@ async fn close_account_fail_unsigned() {
     let mut context = program_test().start_with_context().await;
 
     let authority = Keypair::new();
-    let (solid, _) = instruction::get_solid_address_with_seed(&authority.pubkey());
+    let (solid, _) = get_solid_address_with_seed(&authority.pubkey());
     initialize_did_account(&mut context, &authority.pubkey())
         .await
         .unwrap();

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -20,8 +20,8 @@ use {
         id, instruction,
         processor::process_instruction,
         state::{
-            ClusterType, DecentralizedIdentifier, ServiceEndpoint, SolidData, VerificationMethod,
-            get_solid_address_with_seed
+            get_solid_address_with_seed, ClusterType, DecentralizedIdentifier, ServiceEndpoint,
+            SolidData, VerificationMethod,
         },
     },
 };
@@ -227,10 +227,7 @@ async fn write_fail_wrong_authority() {
         .unwrap();
 
     let (solid, _) = get_solid_address_with_seed(&authority.pubkey());
-    let new_data = SolidData::new_sparse(
-        authority.pubkey(),
-        ClusterType::Development
-    );
+    let new_data = SolidData::new_sparse(authority.pubkey());
     let wrong_authority = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
         &[instruction::write(
@@ -267,10 +264,7 @@ async fn write_fail_unsigned() {
         .await
         .unwrap();
 
-    let new_data = SolidData::new_sparse(
-        authority.pubkey(),
-        ClusterType::Development
-    );
+    let new_data = SolidData::new_sparse(authority.pubkey());
     let data = new_data.try_to_vec().unwrap();
     let transaction = Transaction::new_signed_with_payer(
         &[Instruction::new_with_borsh(

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -19,7 +19,9 @@ use {
         error::SolidError,
         id, instruction,
         processor::process_instruction,
-        state::{ClusterType, DecentralizedIdentifier, ServiceEndpoint, SolidData, VerificationMethod},
+        state::{
+            ClusterType, DecentralizedIdentifier, ServiceEndpoint, SolidData, VerificationMethod,
+        },
     },
 };
 


### PR DESCRIPTION
Optimising storage in the SolidData program by making the following changes (see the [wiki](https://civicteam.atlassian.net/wiki/spaces/ID/pages/1858076717/Optimised+Storage+for+SOLID+DIDs))

- DID no longer stored on-chain as part of the document
- instead the authority is stored on chain
- DID is inferred from the authority at retrieval time and added to the DID Document
- DID urls are relative (i.e the DID component itself is inferred. did:solid:123#key1 becomes key1

TODO (in future PRs)
- do not store the context field on-chain
- infer the verificationMethod from the authority unless specified in the solidData
- prototypes (see the [wiki](https://civicteam.atlassian.net/wiki/spaces/ID/pages/1858076717/Optimised+Storage+for+SOLID+DIDs))
