### PR TITLE
Optimise using inferred verification method

### DIFF
--- a/client/test/e2e/register.test.ts
+++ b/client/test/e2e/register.test.ts
@@ -57,7 +57,7 @@ describe('register', () => {
       payer: payer.secretKey,
       cluster: CLUSTER,
       owner: owner.publicKey.toBase58(),
-      size: 250,
+      size: 150,
     };
     const identifier = await register(registerRequest);
 

--- a/client/test/unit/lib/solana/solid-data.test.ts
+++ b/client/test/unit/lib/solana/solid-data.test.ts
@@ -15,7 +15,7 @@ const withoutAuthority = (solidData: SolidData) =>
 describe('solid-data', () => {
   describe('merge', () => {
     describe('with default behaviour', () => {
-      it('should merge a sparse solidData object into an empty one', () => {
+      it('should merge a sparse solidData object into an empty one, except the authority', () => {
         const empty = SolidData.empty();
         const sparse = SolidData.sparse(
           pub(),
@@ -25,10 +25,10 @@ describe('solid-data', () => {
 
         const merged = empty.merge(sparse);
 
-        expect(merged).toMatchObject(sparse);
+        expect(withoutAuthority(merged)).toEqual(withoutAuthority(sparse));
       });
 
-      it('should not change a sparse solidData object when merging an empty one into it, except for the authority', () => {
+      it('should not change a sparse solidData object when merging an empty one into it', () => {
         const empty = SolidData.empty();
         const sparse = SolidData.sparse(
           pub(),
@@ -38,9 +38,7 @@ describe('solid-data', () => {
 
         const merged = sparse.merge(empty);
 
-        expect(withoutAuthority(merged)).toEqual(withoutAuthority(sparse));
-
-        expect(merged.authority).toEqual(empty.authority);
+        expect(merged).toMatchObject(sparse);
       });
 
       it('should not change a sparse solidData object when merging an empty one with no authority', () => {
@@ -107,7 +105,7 @@ describe('solid-data', () => {
 
         const merged = empty.merge(sparse, true);
 
-        expect(merged).toMatchObject(sparse);
+        expect(withoutAuthority(merged)).toEqual(withoutAuthority(sparse));
       });
 
       it('should clear the contents of a solidData object when merging an empty one', () => {
@@ -120,8 +118,8 @@ describe('solid-data', () => {
 
         const merged = sparse.merge(empty, true);
 
-        expect(merged).toMatchObject({
-          ...empty,
+        expect(withoutAuthority(merged)).toMatchObject({
+          ...withoutAuthority(empty),
           account: sparse.account, // empty SolidData objects have no account
         });
       });

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         id,
-        state::{get_solid_address_with_seed, ClusterType, SolidData},
+        state::{get_solid_address_with_seed, SolidData},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::{
@@ -59,7 +59,6 @@ pub enum SolidInstruction {
 pub fn initialize(
     funder_account: &Pubkey,
     authority: &Pubkey,
-    _cluster_type: ClusterType,
     size: u64,
     init_data: SolidData,
 ) -> Instruction {
@@ -115,7 +114,6 @@ mod tests {
 
     #[test]
     fn serialize_initialize() {
-        let _cluster_type = ClusterType::Development;
         let size = SolidData::DEFAULT_SIZE as u64;
         let init_data = test_solid_data();
         let mut expected = vec![0];

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -24,6 +24,7 @@ use {
 };
 
 fn check_authority(authority_info: &AccountInfo, solid: &SolidData) -> ProgramResult {
+  // TODO - infer authority from authority field
     if !authority_info.is_signer {
         msg!("Solid authority signature missing");
         return Err(ProgramError::MissingRequiredSignature);

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -24,7 +24,6 @@ use {
 };
 
 fn check_authority(authority_info: &AccountInfo, solid: &SolidData) -> ProgramResult {
-  // TODO - infer authority from authority field
     if !authority_info.is_signer {
         msg!("Solid authority signature missing");
         return Err(ProgramError::MissingRequiredSignature);

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -20,8 +20,8 @@ use {
         id, instruction,
         processor::process_instruction,
         state::{
-            get_solid_address_with_seed, ClusterType, DecentralizedIdentifier, ServiceEndpoint,
-            SolidData, VerificationMethod,
+            get_solid_address_with_seed, DecentralizedIdentifier, ServiceEndpoint, SolidData,
+            VerificationMethod,
         },
     },
 };
@@ -39,7 +39,6 @@ async fn initialize_did_account(
         &[instruction::initialize(
             &context.payer.pubkey(),
             authority,
-            ClusterType::Development,
             size as u64,
             SolidData::default(),
         )],
@@ -52,14 +51,19 @@ async fn initialize_did_account(
 
 fn check_solid(data: SolidData, authority: Pubkey) {
     let did = DecentralizedIdentifier::new(&data);
-    let verification_method = VerificationMethod::new(authority);
+    let verification_method = VerificationMethod::new_default(authority);
     assert_eq!(data.context, SolidData::default_context());
     assert_eq!(data.did(), did);
-    assert_eq!(data.verification_method, vec![verification_method.clone()]);
-    assert_eq!(data.authentication, vec![verification_method.id.clone()]);
+    assert_eq!(data.verification_method, vec![]);
     assert_eq!(
-        data.capability_invocation,
-        vec![verification_method.id.clone()]
+        data.inferred_verification_methods(),
+        vec![verification_method.clone()]
+    );
+    assert_eq!(data.authentication, vec![] as Vec<String>);
+    assert_eq!(data.capability_invocation, vec![] as Vec<String>);
+    assert_eq!(
+        data.inferred_capability_invocation(),
+        vec![VerificationMethod::DEFAULT_KEY_ID.to_string()]
     );
     assert_eq!(data.capability_delegation, vec![] as Vec<String>);
     assert_eq!(data.key_agreement, vec![] as Vec<String>);
@@ -94,8 +98,6 @@ async fn initialize_with_service_success() {
     let authority = Pubkey::new_unique();
     let (solid, _) = get_solid_address_with_seed(&authority);
     let mut init_data = SolidData::default();
-    let cluster_type = ClusterType::Development;
-    // let id = DecentralizedIdentifier::new(cluster_type.clone(), authority.clone());
     let endpoint = "http://localhost".to_string();
     let endpoint_type = "local".to_string();
     let description = "A localhost service".to_string();
@@ -110,7 +112,6 @@ async fn initialize_with_service_success() {
         &[instruction::initialize(
             &context.payer.pubkey(),
             &authority,
-            cluster_type,
             SolidData::DEFAULT_SIZE as u64,
             init_data,
         )],
@@ -149,7 +150,6 @@ async fn initialize_twice_fail() {
         &[instruction::initialize(
             &context.payer.pubkey(),
             &authority,
-            ClusterType::Development,
             1,
             SolidData::default(),
         )],
@@ -263,6 +263,62 @@ async fn write_fail_wrong_authority() {
         context
             .banks_client
             .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(SolidError::IncorrectAuthority as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn write_fail_overridden_authority() {
+    let mut context = program_test().start_with_context().await;
+
+    let original_authority = Keypair::new();
+    let new_authority = Keypair::new();
+    let mut init_data = SolidData::default();
+    let new_authority_method = VerificationMethod::new(new_authority.pubkey(), "key1".to_string());
+    init_data.verification_method = vec![new_authority_method];
+    init_data.capability_invocation = vec!["key1".to_string()];
+
+    let create_transaction = Transaction::new_signed_with_payer(
+        &[instruction::initialize(
+            &context.payer.pubkey(),
+            &original_authority.pubkey(),
+            SolidData::DEFAULT_SIZE as u64,
+            init_data,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(create_transaction)
+        .await
+        .unwrap();
+
+    let (solid, _) = get_solid_address_with_seed(&original_authority.pubkey());
+    let new_data = SolidData::new_sparse(original_authority.pubkey());
+
+    let transaction_with_original_authority = Transaction::new_signed_with_payer(
+        &[instruction::write(
+            &solid,
+            &original_authority.pubkey(),
+            0,
+            new_data.try_to_vec().unwrap(),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_authority],
+        context.last_blockhash,
+    );
+    assert_eq!(
+        context
+            .banks_client
+            .process_transaction(transaction_with_original_authority)
             .await
             .unwrap_err()
             .unwrap(),

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -277,6 +277,8 @@ async fn write_fail_wrong_authority() {
 async fn write_fail_overridden_authority() {
     let mut context = program_test().start_with_context().await;
 
+    // create a DID with an authority, but immediately add a new authority to the verification methods
+    // so the original authority is no longer able to use it
     let original_authority = Keypair::new();
     let new_authority = Keypair::new();
     let mut init_data = SolidData::default();
@@ -304,6 +306,7 @@ async fn write_fail_overridden_authority() {
     let (solid, _) = get_solid_address_with_seed(&original_authority.pubkey());
     let new_data = SolidData::new_sparse(original_authority.pubkey());
 
+    // attempt to make a change as the original authority
     let transaction_with_original_authority = Transaction::new_signed_with_payer(
         &[instruction::write(
             &solid,
@@ -315,6 +318,9 @@ async fn write_fail_overridden_authority() {
         &[&context.payer, &original_authority],
         context.last_blockhash,
     );
+
+    // the transaction should fail because
+    // the original authority is no longer authorized to make changes
     assert_eq!(
         context
             .banks_client


### PR DESCRIPTION
Step 2 in the [wiki plan](https://civicteam.atlassian.net/wiki/spaces/ID/pages/1858076717/Optimised+Storage+for+SOLID+DIDs#2.-Inferred-Default-VerificationMethod)

This PR removes the need to explicitly specify the authority's key in the verification method and the ID in the capability invocation of a DID.

If a DID has no verification methods specified, the authority key will always be listed as a verification method with the ID 'default'. Note - *this cannot be removed*, it can only be appended to. If the key is compromised, it should be removed from all the verification method arrays, for example the capability invocation array, which allows the key to edit the DID itself.

The capability invocation array is also a derived field. If not specified, (i.e. an empty array is passed), the derived value will be `['did:solid:<identifier>#default']`. However, if specified, the default value will not be included (unlike with the verification methods array). This allows revocation of the authority key.

With this change, the size of a sparse DID has changed from ~250 bytes after step 1, to ~150 bytes after step 2.