### PR TITLE
Remove the context strings from the on-chain document storage

### DIFF
--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -7,3 +7,6 @@ export const PROGRAM_ID: PublicKey = new PublicKey(
 );
 export const SOLANA_COMMITMENT: Commitment = 'confirmed';
 export const DEFAULT_DOCUMENT_SIZE = 1_000;
+
+export const W3ID_CONTEXT = 'https://w3id.org/did/v1.0';
+export const SOLID_CONTEXT_PREFIX = 'https://w3id.org/solid/v';

--- a/client/test/e2e/register.test.ts
+++ b/client/test/e2e/register.test.ts
@@ -4,6 +4,7 @@ import { Account, Connection } from '@solana/web3.js';
 import { CLUSTER, VALIDATOR_URL } from '../constants';
 import { DecentralizedIdentifier } from '../../src/lib/solana/solid-data';
 import { makeService } from '../util';
+import { SOLID_CONTEXT_PREFIX, W3ID_CONTEXT } from '../../src/lib/constants';
 
 describe('register', () => {
   const connection = new Connection(VALIDATOR_URL, 'recent');
@@ -52,12 +53,34 @@ describe('register', () => {
     expect(doc.service).toEqual([service]);
   }, 30000);
 
+  it('registers a DID with a different version', async () => {
+    const version = '2.3.4';
+
+    const registerRequest: RegisterRequest = {
+      payer: payer.secretKey,
+      cluster: CLUSTER,
+      owner: owner.publicKey.toBase58(),
+      document: {
+        '@context': [W3ID_CONTEXT, SOLID_CONTEXT_PREFIX + version],
+      },
+    };
+    const identifier = await register(registerRequest);
+
+    const doc = await resolve(identifier);
+
+    console.log(JSON.stringify(doc, null, 1));
+
+    // ensure the doc contains the correct version in the context field
+    const context = doc['@context'];
+    expect(context).toEqual([W3ID_CONTEXT, SOLID_CONTEXT_PREFIX + version]);
+  }, 30000);
+
   it('registers a DID with a size', async () => {
     const registerRequest: RegisterRequest = {
       payer: payer.secretKey,
       cluster: CLUSTER,
       owner: owner.publicKey.toBase58(),
-      size: 150,
+      size: 65,
     };
     const identifier = await register(registerRequest);
 

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -52,7 +52,7 @@ async fn initialize_did_account(
 fn check_solid(data: SolidData, authority: Pubkey) {
     let did = DecentralizedIdentifier::new(&data);
     let verification_method = VerificationMethod::new_default(authority);
-    assert_eq!(data.context, SolidData::default_context());
+    assert_eq!(data.version, SolidData::DEFAULT_VERSION);
     assert_eq!(data.did(), did);
     assert_eq!(data.verification_method, vec![]);
     assert_eq!(


### PR DESCRIPTION
Remove the context strings from the on-chain document storage - retain the ability to configure the version. This reduces the minimum size of a sparse DID on-chain from 150 to 65 bytes